### PR TITLE
Add rbnacl-libsodium dependency and resolve version conflicts

### DIFF
--- a/round.gemspec
+++ b/round.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.add_dependency("patchboard", "~> 0.5")
-  s.add_dependency("rbnacl", "~> 2.0")
+  s.add_dependency("rbnacl", "~> 3.0.0")
+  s.add_dependency("rbnacl-libsodium", "~> 1.0.0")
   s.add_dependency("coin-op", "~> 0.2")
 
   # RSpec test suite deps


### PR DESCRIPTION
@jvergeldedios @joshua-bv 

I don't think I have privileges for opening a GitHub Issue, so I figured a PR is the easiest way to get around it.

Not exactly sure what differences there are between rbnacl 2.0 and 3.0, but if the differences do not impact the codebase, I added a dependency for `rbnacl-libsodium`. It's a wrapper gem for libsodium that makes it unnecessary for developers to include the libsodium library independently. Not sure what your other clients are using for production environments, but with Heroku, I would need to create a custom buildpack in order to use libsodium. You may have reasons to require this, and if so then disregard this pull request.
