### PR TITLE
Require libsodium

### DIFF
--- a/lib/round.rb
+++ b/lib/round.rb
@@ -1,3 +1,4 @@
+require 'rbnacl/libsodium'
 require 'coin-op'
 
 # Establish the namespace.


### PR DESCRIPTION
Last PR did not include the necessary require statement for rbnacl to see the bundled libsodium.
