### PR TITLE
Cleanup the README and Unpinned the Version Info By Using Rake

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ For detailed usage please visit the [documentation page](https://guide.gem.co)
 
 ### Install gem dependencies:
 
+    $ git clone https://github.com/gemhq/round-rb
+    $ cd round-rb
     $ bundle install
 
 ### Build and install the gem:
 
-    $ gem build round.gemspec
-    $ gem install round-0.6.0.gem
+    $ bundle exec rake build
+    $ bundle exec rake install
 
 ## Configuration
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,11 @@
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
+Bundler::GemHelper.install_tasks
+
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new


### PR DESCRIPTION
Doing this makes it so the README doesn't have to change so often after builds and is a bit more explicit on the dependencies to make sure everyone is building with the same gems.